### PR TITLE
Refactor: Align Welcome fragment naming with conventions

### DIFF
--- a/app/src/main/java/com/example/brewlycoffee/MainActivity.kt
+++ b/app/src/main/java/com/example/brewlycoffee/MainActivity.kt
@@ -22,7 +22,7 @@ class MainActivity : AppCompatActivity() {
         val getStartedButton: Button = findViewById(R.id.button)
         getStartedButton.setOnClickListener {
             supportFragmentManager.beginTransaction()
-                .replace(R.id.main, Welcome())
+                .replace(R.id.main, WelcomeFragment())
                 .addToBackStack(null)
                 .commit()
         }

--- a/app/src/main/java/com/example/brewlycoffee/WelcomeFragment.kt
+++ b/app/src/main/java/com/example/brewlycoffee/WelcomeFragment.kt
@@ -16,7 +16,7 @@ private const val ARG_PARAM2 = "param2"
  * Use the [Welcome.newInstance] factory method to
  * create an instance of this fragment.
  */
-class Welcome : Fragment() {
+class WelcomeFragment : Fragment() {
     // TODO: Rename and change types of parameters
     private var param1: String? = null
     private var param2: String? = null
@@ -49,7 +49,7 @@ class Welcome : Fragment() {
         // TODO: Rename and change types and number of parameters
         @JvmStatic
         fun newInstance(param1: String, param2: String) =
-            Welcome().apply {
+            WelcomeFragment().apply {
                 arguments = Bundle().apply {
                     putString(ARG_PARAM1, param1)
                     putString(ARG_PARAM2, param2)


### PR DESCRIPTION
Welcome.kt renamed to WelcomeFragment.kt and updated the class name from Welcome to WelcomeFragment.

This change improves adherence to standard Android development naming conventions for Fragments. The instantiation in MainActivity and internal references within WelcomeFragment have been updated accordingly.